### PR TITLE
Add devcontainer definition

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,5 @@
+{
+    "name": "Ruby",
+    "image": "mcr.microsoft.com/devcontainers/ruby:3",
+    "onCreateCommand": "bundle install"
+}  


### PR DESCRIPTION
A devcontainer allows you to quickly create a development environment either on Github Codespaces, or locally in VSCode with the dependencies exactly like they have to be for the project. Makes it super quick for anyone to get the page build locally and to contribute.

The project uses `ruby@2.3`, so using a `ruby@3` image isn't exactly the same, but it worked for me as long as I didn't commit the `Gemfile.lock` which would presumably break the CI build without updating that to `3` too.